### PR TITLE
Fork; nudge request library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var tilelive = require('@mapbox/tilelive');
 var tiletype = require('@mapbox/tiletype');
 var mapnik = require('mapnik');
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@mapbox/tilelive-vector",
-  "version": "4.2.0",
+  "name": "@wikimedia/tilelive-vector",
+  "version": "4.2.1",
   "main": "./index.js",
   "description": "Vector tile => raster tile backend for tilelive",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mapbox/tilelive-vector.git"
+    "url": "git://github.com/wikimedia/tilelive-vector.git"
   },
   "licenses": [
     {
@@ -20,7 +20,7 @@
     "@mapbox/tilelive": "~5.12.0",
     "@mapbox/tiletype": "0.3.x",
     "numeral": "~1.5.3",
-    "request": "~2.83.0",
+    "request": "^2.88.2",
     "spherical": "~0.1.0",
     "tar": "~2.2.1",
     "underscore": "~1.8.0"


### PR DESCRIPTION
The request library is deprecated, but on our mapnik-4 branch we had success updating it to the last release.

Bug: T323919