### PR TITLE
Fork; nudge request library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var tilelive = require('@mapbox/tilelive');
 var tiletype = require('@mapbox/tiletype');
 var mapnik = require('@kartotherian/mapnik');
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@kartotherian/tilelive-vector",
-  "version": "4.0.3-alpha.0",
+  "name": "@wikimedia/tilelive-vector",
+  "version": "4.0.4-alpha.0",
   "main": "./index.js",
   "description": "Vector tile => raster tile backend for tilelive",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mapbox/tilelive-vector.git"
+    "url": "git://github.com/wikimedia/tilelive-vector.git"
   },
   "licenses": [
     {
@@ -21,7 +21,7 @@
     "@mapbox/tiletype": "0.3.x",
     "aws-sdk": "^2.2.30",
     "numeral": "~1.5.3",
-    "request": "~2.83.0",
+    "request": "^2.88.2",
     "s3urls": "^1.3.0",
     "spherical": "~0.1.0",
     "tar": "~2.2.1",


### PR DESCRIPTION
The request library is deprecated, but on our mapnik-4 branch we had success updating it to the last release.

Bug: T323919